### PR TITLE
Replacing link to broken guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -617,7 +617,7 @@ gem 'carrierwave'</code></pre>
 					<ul>
 						<li><a href="http://guides.railsgirls.com/commenting" target="_blank">Allow comments</a></li>
 						<li><a href="http://guides.railsgirls.com/devise" target="_blank">Add authentication</a></li>
-						<li><a href="http://guides.railsgirls.com/design-html-css" target="_blank">Improve your design</a></li>
+						<li><a href="http://guides.railsgirls.com/design" target="_blank">Improve your design</a></li>
 						<li><a href="http://guides.railsgirls.com/thumbnails" target="_blank">Resize images using Carrierwave*</a> </li>
 					</ul>
 					<p><small>*If you'd like to do this one, you won't need to complete the 'brew install imagemagick' step. Nitrous comes with this already!</small></p>


### PR DESCRIPTION
The Design with HTML and CSS guide is a bit crappy and also broken.
